### PR TITLE
Add force_push_slack option to logging methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ logger.set_slack_level('WARNING')
 
 # Now the logs will be log to slack
 logger.warning('Some Dummy log', 'Some dummy details of the dummy log')
+
+# You can also do a force push to slack no matter what the slack level is set.
+logger.info('Dummy log', 'Details of the dummy log', force_push_slack=True)
 ```
 
 See [python logging docs](https://docs.python.org/3/library/logging.html) for more uses.


### PR DESCRIPTION
This commit adds force_push_option to aklogger
info, debug, warning, error, _log methods to
push the logs to slack no matter what the slack
level is set.

Also add a method to get the slack color
based on the levels.